### PR TITLE
Add 7.6.0 on arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,11 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/include/xsimd/xsimd.hpp  # [unix]
-    - test -f ${PREFIX}/lib/cmake/xsimd/xsimdConfig.cmake  # [unix]
-    - test -f ${PREFIX}/lib/cmake/xsimd/xsimdConfigVersion.cmake  # [unix]
-    - if not exist %LIBRARY_PREFIX%\include\xsimd\xsimd.hpp (exit 1)  # [win]
-    - if not exist %LIBRARY_PREFIX%\lib\cmake\xsimd\xsimdConfig.cmake (exit 1)  # [win]
+    - test -f ${PREFIX}/include/xsimd/xsimd.hpp                       # [unix]
+    - test -f ${PREFIX}/lib/cmake/xsimd/xsimdConfig.cmake             # [unix]
+    - test -f ${PREFIX}/lib/cmake/xsimd/xsimdConfigVersion.cmake      # [unix]
+    - if not exist %LIBRARY_PREFIX%\include\xsimd\xsimd.hpp (exit 1)                   # [win]
+    - if not exist %LIBRARY_PREFIX%\lib\cmake\xsimd\xsimdConfig.cmake (exit 1)         # [win]
     - if not exist %LIBRARY_PREFIX%\lib\cmake\xsimd\xsimdConfigVersion.cmake (exit 1)  # [win]
 
 about:


### PR DESCRIPTION
`pythran 0.10.`0 requires `xsimd ~7.6.*`, see https://github.com/AnacondaRecipes/pythran-feedstock/pull/3#issuecomment-982555242