### PR TITLE
update `xsimd` to version `8.1.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xsimd" %}
-{% set version = "8.0.5" %}
-{% set sha256 = "0e1b5d973b63009f06a3885931a37452580dbc8d7ca8ad40d4b8c80d2a0f84d7" %}
+{% set version = "8.1.0" %}
+{% set sha256 = "d52551360d37709675237d2a0418e28f70995b5b7cdad7c674626bcfbbf48328" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION

`xsimd` version `8.1.0`
1. - [X] Check the upstream
    https://github.com/xtensor-stack/xsimd/tree/8.1.0
2. - [X] Check the pinnings
3. - [X] Check the changelogs
    There is currently no changelogs so the pull requests were reviewed instead
    https://github.com/xtensor-stack/xsimd/pulls
4. - [X] Additional research
    https://github.com/conda-forge/xsimd-feedstock/issues
 
    There is currently an open issue with version `9.0.1`
    This however does not affect our build since we are building version `8.1.0`

5. - [X] Verify the `dev_url`
    https://github.com/xtensor-stack/xsimd
6. - [X] Verify the `doc_url`
    https://xsimd.readthedocs.io/en/latest/
7. - [X] License is `spdx` compliant
    BSD-3-Clause
8. - [X] License family is present
    BSD
9. - [X] Verify that the `build_number` is correct
10. - [X] Verify if the package needs `setuptools`
    The package is a `C/C++` package so we do not need `setuptools`
11. - [X] Verify if the package needs `wheel`
    The package is a `C/C++` package so we do not need `wheel`
12. - [X] `pip` in the test section
    The package is a `C/C++` package so we do not need `pip`
13. - [X] Veriy the test section
14. - [X] Verify if the package is `architecture specific` or `Noarch`
15. - [X] Verify that private modules are not mentioned on the recipe For example: (_private_module)
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is safe to update `xsimd` to version `8.1.0`

