### PR TITLE
Build 7.4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xsimd" %}
-{% set version = "11.0.0" %}
-{% set sha256 = "50c31c319c8b36c8946eb954c7cca2e2ece86bf8a66a7ebf321b24cd273e7c47" %}
+{% set version = "7.4.4" %}
+{% set sha256 = "a60d49f638b68117ae5aea73cf2d5586f4afda4de2435962de4310b11214de6a" %}
 
 package:
   name: {{ name|lower }}
@@ -9,8 +9,6 @@ package:
 source:
   url: https://github.com/xtensor-stack/xsimd/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
-  patches:
-    - patches/cpp11_compatibility.patch
 
 build:
   number: 0
@@ -20,8 +18,6 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make      # [unix]
-    - patch     # [unix]
-    - m2-patch  # [win]
 
 test:
   commands:


### PR DESCRIPTION
xsimd 7.4.4

**Destination channel:** defaults

### Links

- [PKG-3845](https://anaconda.atlassian.net/browse/PKG-3845)
- [Upstream repository](https://github.com/xtensor-stack/xsimd/tree/7.4.4)

### Explanation of changes:

7.4.4 is an old version. We need this exact version for `xtensor`, see https://github.com/xtensor-stack/xtensor/blob/0.23.5/CMakeLists.txt#L62.


[PKG-3845]: https://anaconda.atlassian.net/browse/PKG-3845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ